### PR TITLE
Google Cloud 실행 시 문제 해결

### DIFF
--- a/config.js
+++ b/config.js
@@ -5,7 +5,8 @@
  */
 
 const moment = require('moment')
-const uniqid = require('uniqid')
+const nanoidGenerate = require('nanoid/generate')
+const generate = () => nanoidGenerate('1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', 32)
 const HmacSHA256 = require('crypto-js/hmac-sha256')
 const fs = require('fs')
 const path = require('path')
@@ -16,7 +17,7 @@ module.exports = {
     switch (headerType) {
       case 1:
         const date = moment.utc().format()
-        const salt = uniqid()
+        const salt = generate()
         const hmacData = date + salt
         const signature = HmacSHA256(hmacData, apiSecret).toString()
         return `HMAC-SHA256 apiKey=${apiKey}, date=${date}, salt=${salt}, signature=${signature}`

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "crypto-js": "^3.1.9-1",
     "fs": "0.0.1-security",
     "moment": "^2.22.1",
+    "nanoid": "^2.0.3",
     "path": "^0.12.7",
     "qs": "^6.5.2",
-    "request": "^2.85.0",
-    "uniqid": "^4.1.1"
+    "request": "^2.85.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
Google Cloud 실행 시 아래와 같은 오류가 발생한다는 리포트가 있었습니다.

["salt" 유효성 검사 실패 ["salt" 의 "08jxctfv8i" 값은 유효하지 않습니다. /^[a-zA-Z0-9]{12,64}$/ 정규식 패턴과 일치해야 합니다.]]

기존 사용하고 있는 uniqid 가 특정 환경에서 10자리의 해시값을 리턴하는 것 같습니다.
해시값의 자리수를 지정할 수 있는 nanoid 로 변경했습니다.